### PR TITLE
Resolved issues #22, #27, #30, #31

### DIFF
--- a/Rebracer/Services/SettingsLocator.cs
+++ b/Rebracer/Services/SettingsLocator.cs
@@ -26,6 +26,37 @@ namespace SLaks.Rebracer.Services {
 
 		///<summary>Gets the path to a solution-specific settings file.</summary>
 		public string SolutionPath(Solution solution) {
+
+			if (String.IsNullOrWhiteSpace(solution.FileName))
+				return null;
+
+			string root = Path.GetPathRoot(solution.FileName);
+			string path = Path.GetDirectoryName(solution.FileName).Substring(root.Length);
+			string file = Path.Combine(root, path, FileName);
+
+			if (File.Exists(file))
+				return file;
+
+			int index = path.LastIndexOf(Path.DirectorySeparatorChar);
+
+			while (index != -1) {
+
+				path = path.Substring(0, index);
+				file = Path.Combine(root, path, FileName);
+
+				if (File.Exists(file))
+					return file;
+
+				index = path.LastIndexOf(Path.DirectorySeparatorChar);
+			}
+
+			if( index == -1 ) {
+				file = Path.Combine(root, FileName);
+
+				if (File.Exists(file))
+					return file;
+			}
+
 			return Path.Combine(Path.GetDirectoryName(solution.FileName), FileName);
 		}
 


### PR DESCRIPTION
Resolved issue #31: Exception from HRESULT: 0x80020003 (DISP_E_MEMBERNOTFOUND) while settings file is readed and applied. This error occurs when property value is read-only.

Resolved issue #30: Exception from HRESULT: 0x80070057 (E_INVALIDARG) while settings file is readed and applied. This error occurs when the IDE property does not exist at this time. Non-existent properties are removed from the settings file. 

Resolved issue #27: Exception from HRESULT: 0x80070057 (E_INVALIDARG) while settings file is readed and applied. This error occurs when the IDE property does not exist at this time. Non-existent properties are removed from the settings file. 

Resolved issue #22: Added support for ancestor folder location for Rebracer.xml. Rebracer file is searched from solution folder to root of solution folder drive.

Tested under VS 2017.